### PR TITLE
fix: Breaking typo in 0005-remove-dupe-multi-user-target.patch

### DIFF
--- a/debian/patches/0005-remove-dupe-multi-user-target.patch
+++ b/debian/patches/0005-remove-dupe-multi-user-target.patch
@@ -12,7 +12,7 @@ Last-Updated: 2022-12-05
  After=network-online.target rsyslog.service google-guest-agent.service
  Before=apt-daily.service
 -After=cloud-final.service multi-user.target
-+After=cloud-final.servicer
++After=cloud-final.service
  Wants=cloud-final.service
  After=snapd.seeded.service
  Wants=snapd.seeded.service


### PR DESCRIPTION
@utkarsh2102 So... I messed up the patch :frowning_face: There was a trailing "r" typo that will almost definitely break the service file as is. Do I need to create another d/changelog entry? I will if I need to and add it as an extra commit here :smile: 